### PR TITLE
allow user to pass consistency mode when reading kv store data.

### DIFF
--- a/Consul/Services/KV.php
+++ b/Consul/Services/KV.php
@@ -17,7 +17,7 @@ final class KV implements KVInterface
     public function get($key, array $options = array())
     {
         $params = array(
-            'query' => OptionsResolver::resolve($options, array('dc', 'recurse', 'keys', 'separator', 'raw')),
+            'query' => OptionsResolver::resolve($options, array('dc', 'recurse', 'keys', 'separator', 'raw', 'stale', 'consistent', 'default')),
         );
 
         return $this->client->get('v1/kv/'.$key, $params);


### PR DESCRIPTION
These modes can be:
* default: strong consistency
* consistent: strong consistency
* stale: can read data regardless of whether it is a leader.
More information here: https://www.consul.io/api/index.html#consistency-modes


example usage:
```
$this->kv->get('test/my/key', ["stale"=>true]);
```