### PR TITLE
Exclude the bin folder from archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
             "dev-master": "2.0-dev"
         }
     },
+    "archive": {
+      "exclude": ["bin/"]
+    },
     "require-dev": {
         "symfony/process": "~2.5",
         "symfony/filesystem": "~2.5",


### PR DESCRIPTION
This makes sure that the Cosul binaries used for testing are not
distributed in the Composer package.