### PR TITLE
Use PUT HTTP verb to register a service

### DIFF
--- a/Consul/Services/Catalog.php
+++ b/Consul/Services/Catalog.php
@@ -20,7 +20,7 @@ final class Catalog implements CatalogInterface
             'body' => (string) $node,
         );
 
-        return $this->client->get('/v1/catalog/register', $params);
+        return $this->client->put('/v1/catalog/register', $params);
     }
 
     public function deregister($node)


### PR DESCRIPTION
To create a new service in Consul, the PUT verb should be used with the API /catalog/register
See https://www.consul.io/api-docs/catalog#register-entity