### PR TITLE
Issue#49: Replace Guzzle Http Client with Symfony Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-    - 5.6
-    - 7.0
-    - 7.1
     - 7.2
+    - 7.3
+    - 7.4
 
 branches:
     only:

--- a/Consul/ServiceFactory.php
+++ b/Consul/ServiceFactory.php
@@ -2,7 +2,6 @@
 
 namespace SensioLabs\Consul;
 
-use GuzzleHttp\Client as GuzzleClient;
 use Psr\Log\LoggerInterface;
 use SensioLabs\Consul\Services\Agent;
 use SensioLabs\Consul\Services\AgentInterface;
@@ -14,6 +13,7 @@ use SensioLabs\Consul\Services\KV;
 use SensioLabs\Consul\Services\KVInterface;
 use SensioLabs\Consul\Services\Session;
 use SensioLabs\Consul\Services\SessionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class ServiceFactory
 {
@@ -34,9 +34,9 @@ final class ServiceFactory
 
     private $client;
 
-    public function __construct(array $options = array(), LoggerInterface $logger = null, GuzzleClient $guzzleClient = null)
+    public function __construct(array $options = array(), LoggerInterface $logger = null, HttpClientInterface $httpClient = null)
     {
-        $this->client = new Client($options, $logger, $guzzleClient);
+        $this->client = new Client($options, $logger, $httpClient);
     }
 
     public function get($service)

--- a/Consul/Tests/Services/KVTest.php
+++ b/Consul/Tests/Services/KVTest.php
@@ -2,9 +2,7 @@
 
 namespace SensioLabs\Consul\Tests\Services;
 
-use GuzzleHttp\Message\ResponseInterface;
 use SensioLabs\Consul\ConsulResponse;
-use SensioLabs\Consul\Exception\ClientException;
 use SensioLabs\Consul\Services\KV;
 
 class KVTest extends AbstractTest
@@ -82,7 +80,7 @@ class KVTest extends AbstractTest
             $this->fail('fail because the key does not exist anymore.');
         } catch (\Exception $e) {
             $this->assertInstanceOf('SensioLabs\Consul\Exception\ClientException', $e);
-            $this->assertContains('404 - Not Found', $e->getMessage());
+            $this->assertContains('404', $e->getMessage());
         }
     }
 
@@ -104,7 +102,7 @@ class KVTest extends AbstractTest
                 $this->fail('fail because the key does not exist anymore.');
             } catch (\Exception $e) {
                 $this->assertInstanceOf('SensioLabs\Consul\Exception\ClientException', $e);
-                $this->assertContains('404 - Not Found', $e->getMessage());
+                $this->assertContains('404', $e->getMessage());
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Consul SDK
 Compatibility
 -------------
 
-This table shows this SDK compatibility regarding Guzzle version:
+This table shows this SDK compatibility regarding supported Guzzle/Symfony http client versions:
 
-| SDK Version | Guzzle Version
-| ----------- | --------------
-| 1.x         | >=4, <6
-| 2.x         | 6
+| SDK Version | Guzzle Version | Symfony HTTP Client |
+| ----------- | -------------- | ------------------- |
+| 1.x         | >=4, <6        | N/A                 | 
+| 2.x         | 6              | N/A                 |
+| 3.x         | N/A            | 5                   |
 
 Installation
 ------------
@@ -49,7 +50,7 @@ $response = $service->method($mandatoryArgument, $someOptions);
 
 * All API mandatory arguments are placed as first;
 * All API optional arguments are directly mapped from `$someOptions`;
-* All methods return raw guzzle response.
+* All methods return a raw http client response.
 
 So if you want to acquire an exclusive lock:
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "symfony/http-client": "^5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR tackles issue #49 
Please see the altered test changes for `getReasonPhrase`, otherwise all tests pass like before with the new client.