### PR TITLE
New method for Agent + exported client

### DIFF
--- a/Consul/Services/Agent.php
+++ b/Consul/Services/Agent.php
@@ -14,6 +14,11 @@ final class Agent implements AgentInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function checks()
     {
         return $this->client->get('/v1/agent/checks');
@@ -106,4 +111,10 @@ final class Agent implements AgentInterface
     {
         return $this->client->put('/v1/agent/service/deregister/'.$serviceId);
     }
+
+    public function serviceConfiguration($serviceId)
+    {
+        return $this->client->get('/v1/agent/service/'.$serviceId);
+    }
+
 }

--- a/Consul/Services/AgentInterface.php
+++ b/Consul/Services/AgentInterface.php
@@ -8,6 +8,8 @@ interface AgentInterface
 {
     const SERVICE_NAME = 'agent';
 
+    public function client();
+
     public function checks();
 
     public function services();
@@ -33,4 +35,6 @@ interface AgentInterface
     public function registerService($service);
 
     public function deregisterService($serviceId);
+
+    public function serviceConfiguration($serviceId);
 }

--- a/Consul/Services/Catalog.php
+++ b/Consul/Services/Catalog.php
@@ -14,6 +14,11 @@ final class Catalog implements CatalogInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function register($node)
     {
         $params = array(

--- a/Consul/Services/CatalogInterface.php
+++ b/Consul/Services/CatalogInterface.php
@@ -8,6 +8,8 @@ interface CatalogInterface
 {
     const SERVICE_NAME = 'catalog';
 
+    public function client();
+
     public function register($node);
 
     public function deregister($node);

--- a/Consul/Services/Health.php
+++ b/Consul/Services/Health.php
@@ -14,6 +14,11 @@ final class Health implements HealthInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function node($node, array $options = array())
     {
         $params = array(

--- a/Consul/Services/HealthInterface.php
+++ b/Consul/Services/HealthInterface.php
@@ -8,6 +8,8 @@ interface HealthInterface
 {
     const SERVICE_NAME = 'health';
 
+    public function client();
+
     public function node($node, array $options = array());
 
     public function checks($service, array $options = array());

--- a/Consul/Services/KV.php
+++ b/Consul/Services/KV.php
@@ -14,6 +14,11 @@ final class KV implements KVInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function get($key, array $options = array())
     {
         $params = array(

--- a/Consul/Services/KVInterface.php
+++ b/Consul/Services/KVInterface.php
@@ -8,7 +8,11 @@ interface KVInterface
 {
     const SERVICE_NAME = 'kv';
 
+    public function client();
+
     public function get($key, array $options = array());
+
     public function put($key, $value, array $options = array());
+    
     public function delete($key, array $options = array());
 }

--- a/Consul/Services/Session.php
+++ b/Consul/Services/Session.php
@@ -14,6 +14,11 @@ final class Session implements SessionInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function create($body = null, array $options = array())
     {
         $params = array(

--- a/Consul/Services/SessionInterface.php
+++ b/Consul/Services/SessionInterface.php
@@ -8,6 +8,8 @@ interface SessionInterface
 {
     const SERVICE_NAME = 'session';
 
+    public function client();
+
     public function create($body = null, array $options = array());
 
     public function destroy($sessionId, array $options = array());

--- a/Consul/Services/TXN.php
+++ b/Consul/Services/TXN.php
@@ -15,6 +15,11 @@ final class TXN implements TXNInterface
         $this->client = $client ?: new Client();
     }
 
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function put(array $operations = array(), array $options = array())
     {
         $this->validate($operations);

--- a/Consul/Services/TXNInterface.php
+++ b/Consul/Services/TXNInterface.php
@@ -8,5 +8,7 @@ interface TXNInterface
 {
     const SERVICE_NAME = 'txn';
 
+    public function client();
+
     public function put(array $operations = array());
 }


### PR DESCRIPTION
Added missing method to Agent class, as well as exported client from all classes, as it might help to avoid commits like this from happening (developer would be able to create custom requests if needed)

**Reasons for this PR:**
1. One method is missing from the `Agent` class
2. In my opinion, `$this->client` should be exported, so developer can take advantage of any custom routes they might need later down the line

I understand that some of the routes might not be as useful as others, I still think they should be either implemented, or Client should be exported so developers would be able to write their own handlers for these types of situations.
