### PR TITLE
Ignore Consul binaries in archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/bin export-ignore
+/consul-configuration export-ignore


### PR DESCRIPTION
Ignores the Consul binaries when creating the archives and thereby reduces the size of the install.

Resolves #53