### PR TITLE
Support psr/log 2.x and 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "psr/log": "~1.0",
+        "psr/log": "^1|^2|^3",
         "symfony/http-client": "^5.1|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Add compatibility with the newer `LoggerInterface` and `PHP` versions - similar to https://github.com/symfony/http-client/blob/5.4/composer.json#L25 or https://github.com/symfony/symfony/blob/6.1/composer.json#L46