### PR TITLE
Replace Consul\Client class requirement with Consul\ClientInterface

### DIFF
--- a/src/Services/Agent.php
+++ b/src/Services/Agent.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class Agent
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Services/Catalog.php
+++ b/src/Services/Catalog.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class Catalog
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Services/Health.php
+++ b/src/Services/Health.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class Health
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Services/KV.php
+++ b/src/Services/KV.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class KV
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Services/Session.php
+++ b/src/Services/Session.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class Session
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Services/TXN.php
+++ b/src/Services/TXN.php
@@ -3,14 +3,15 @@
 namespace Consul\Services;
 
 use Consul\Client;
+use Consul\ClientInterface;
 use Consul\ConsulResponse;
 use Consul\OptionsResolver;
 
 final class TXN
 {
-    private Client $client;
+    private ClientInterface $client;
 
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }


### PR DESCRIPTION
`Consul\Client` class is marked as final and, despite implementing `Consul\ClientInterface`, is required in all service classes.
It causes a tight coupling, making it impossible to replace the client. or mock in a unit test.

The simplest solution seems to be to replace the requirement of `Consul\Client` with `Consul\ClientInterface` as the interface is already there, only never used inside the library.